### PR TITLE
Add docker build for kelpie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:jdk8
+FROM openjdk:8u212-jre-slim-stretch
 
 COPY ./kelpie.tar .
 
@@ -7,11 +7,5 @@ RUN tar xf kelpie.tar && rm -f kelpie.tar
 RUN mv kelpie/bin/* /usr/local/bin/ && \
     mv kelpie/lib/* /usr/local/lib/ && \
     rm -rf kelpie
-
-RUN git clone https://github.com/scalar-labs/kelpie-test.git kelpie-test && \
-    cd kelpie-test/client-test && \
-    gradle shadowJar
-
-WORKDIR /home/gradle/kelpie-test/
 
 ENTRYPOINT [ "/usr/local/bin/kelpie" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM gradle:jdk8
+
+RUN git clone https://github.com/scalar-labs/kelpie.git kelpie && \
+    cd kelpie && ./gradlew installDist && \ 
+    cd .. && \
+    mv /home/gradle/kelpie/build/install/kelpie/bin/* /usr/local/bin/ && \
+    mv /home/gradle/kelpie/build/install/kelpie/lib/* /usr/local/lib/ && \
+    rm -rf kelpie
+
+RUN git clone https://github.com/scalar-labs/kelpie-test.git kelpie-test && \
+    cd kelpie-test/client-test && \
+    gradle shadowJar
+
+WORKDIR /home/gradle/kelpie-test/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM gradle:jdk8
 
-RUN git clone https://github.com/scalar-labs/kelpie.git kelpie && \
-    cd kelpie && ./gradlew installDist && \ 
-    cd .. && \
-    mv /home/gradle/kelpie/build/install/kelpie/bin/* /usr/local/bin/ && \
-    mv /home/gradle/kelpie/build/install/kelpie/lib/* /usr/local/lib/ && \
+COPY ./kelpie.tar .
+
+RUN tar xf kelpie.tar && rm -f kelpie.tar
+
+RUN mv kelpie/bin/* /usr/local/bin/ && \
+    mv kelpie/lib/* /usr/local/lib/ && \
     rm -rf kelpie
 
 RUN git clone https://github.com/scalar-labs/kelpie-test.git kelpie-test && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,5 @@ RUN git clone https://github.com/scalar-labs/kelpie-test.git kelpie-test && \
     gradle shadowJar
 
 WORKDIR /home/gradle/kelpie-test/
+
+ENTRYPOINT [ "/usr/local/bin/kelpie" ]

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'application'
+    id 'com.palantir.docker' version '0.25.0'
 }
 
 mainClassName = 'com.scalar.kelpie.Kelpie'
@@ -31,6 +32,11 @@ task sourcesJar(type: Jar) {
 task javadocJar(type: Jar) {
     classifier = 'javadoc'
     from javadoc
+}
+
+docker {
+    name 'scalarlabs/kelpie'
+    files tasks.distTar.outputs
 }
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
# Goal

add `dockerfile` for kelpie - following the discussion here  https://github.com/scalar-labs/scalar-k8s/pull/31/files#r452590819

```console
$ ./gradlew docker

BUILD SUCCESSFUL in 2s
8 actionable tasks: 3 executed, 5 up-to-date
```

```console
docker run -ti scalarlabs/kelpie
Missing required option '--config=<CONFIG_FILE>'
Usage: kelpie [-hV] [--except-post] [--except-pre] [--except-process]
              [--inject] [--only-post] [--only-pre] [--only-process]
              --config=<CONFIG_FILE>
Execute a job built with Kelpie framework.
      --config=<CONFIG_FILE>
                         A config file of a job
      --except-post      Execute except post-process
      --except-pre       Execute except pre-process
      --except-process   Execute except process
  -h, --help             Show this help message and exit.
      --inject           Execute the injectors
      --only-post        Execute only the post-process
      --only-pre         Execute only the pre-process
      --only-process     Execute only the process
  -V, --version          Print version information and exit.
```

# Reference

Jira: soon