### PR TITLE
executeEach() throws Exception

### DIFF
--- a/src/main/java/com/scalar/kelpie/modules/FrequencyBasedProcessor.java
+++ b/src/main/java/com/scalar/kelpie/modules/FrequencyBasedProcessor.java
@@ -48,5 +48,5 @@ public abstract class FrequencyBasedProcessor extends Processor {
    * num_operations}. If a failure which you don't want to record its latency happens, this method
    * should throw an exception. The exception will be caught in {@link #execute()}.
    */
-  protected abstract void executeEach();
+  protected abstract void executeEach() throws Exception;
 }

--- a/src/main/java/com/scalar/kelpie/modules/TimeBasedProcessor.java
+++ b/src/main/java/com/scalar/kelpie/modules/TimeBasedProcessor.java
@@ -47,5 +47,5 @@ public abstract class TimeBasedProcessor extends Processor {
    * run_for_sec}. If a failure which you don't want to record its latency happens, this method
    * should throw an exception. The exception will be caught in {@link #execute()}.
    */
-  protected abstract void executeEach();
+  protected abstract void executeEach() throws Exception;
 }


### PR DESCRIPTION
Before https://scalar-labs.atlassian.net/browse/DLT-6134, `executeEach()` should throw Exception explicitly.