### PR TITLE
Add a fatal exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ public class FrequencyBasedPrintProcessor extends FrequencyBasedProcessor {
 }
 ```
 
+You can make the job fail by throwing `ProcessFatalException` when a fatal error happens in `executeEach()`.
+
 ## PostProcessor
 `PostProcessor` executes the last process in a job after all `Processor#execute()` finish. For example, if it is verifying database consistency, `PostProcessor` reads all the records of the database and checks if their values are as expected. `PostProcessor#execute()` is always executed with a single thread.
 

--- a/src/main/java/com/scalar/kelpie/exception/ProcessFatalException.java
+++ b/src/main/java/com/scalar/kelpie/exception/ProcessFatalException.java
@@ -1,0 +1,12 @@
+package com.scalar.kelpie.exception;
+
+public class ProcessFatalException extends ProcessException {
+
+  public ProcessFatalException(String message) {
+    super(message);
+  }
+
+  public ProcessFatalException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/scalar/kelpie/modules/FrequencyBasedProcessor.java
+++ b/src/main/java/com/scalar/kelpie/modules/FrequencyBasedProcessor.java
@@ -1,6 +1,7 @@
 package com.scalar.kelpie.modules;
 
 import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.exception.ProcessFatalException;
 import com.scalar.kelpie.stats.Stats;
 import java.util.function.Supplier;
 import java.util.stream.LongStream;
@@ -20,6 +21,8 @@ public abstract class FrequencyBasedProcessor extends Processor {
           try {
             executeEach();
             return true;
+          } catch (ProcessFatalException e) {
+            throw e;
           } catch (Exception e) {
             return false;
           }

--- a/src/main/java/com/scalar/kelpie/modules/TimeBasedProcessor.java
+++ b/src/main/java/com/scalar/kelpie/modules/TimeBasedProcessor.java
@@ -1,6 +1,7 @@
 package com.scalar.kelpie.modules;
 
 import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.exception.ProcessFatalException;
 import com.scalar.kelpie.stats.Stats;
 import java.util.function.Supplier;
 
@@ -19,6 +20,8 @@ public abstract class TimeBasedProcessor extends Processor {
           try {
             executeEach();
             return true;
+          } catch (ProcessFatalException e) {
+            throw e;
           } catch (Exception e) {
             return false;
           }


### PR DESCRIPTION
In a verification test, I want to make a job fail when a fatal error happens in `executeEach()` like in `TimeBasedProcessor`.
The current `TimeBasedProcessor` and `FrequencyBasedProcessor` catch all exceptions and keep running.
I add `ProcessFatalException`. If it is thrown from `executeEach()`, these processors throw it to `KelpieExecutor` and a job fails.