### PR TITLE
Fix rounding logic in Stats

### DIFF
--- a/src/main/java/com/scalar/kelpie/stats/Stats.java
+++ b/src/main/java/com/scalar/kelpie/stats/Stats.java
@@ -2,7 +2,7 @@ package com.scalar.kelpie.stats;
 
 import com.scalar.kelpie.config.Config;
 import java.math.BigDecimal;
-import java.math.MathContext;
+import java.math.RoundingMode;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import org.HdrHistogram.ConcurrentHistogram;
@@ -160,7 +160,7 @@ public class Stats {
 
   private double round(double v) {
     return new BigDecimal(v)
-        .round(new MathContext((int) config.getSignificantDigits()))
+        .setScale((int) config.getSignificantDigits(), RoundingMode.HALF_UP)
         .doubleValue();
   }
 


### PR DESCRIPTION
The current rounding logic is not good. For example, if the total success count is `563363` and the `run_for_sec` is 300, the actual throughput is `563363 / 300 = 1877.8766666666668`, but currently, the throughput is shown as `1880.0`, which is not very accurate. Currently, we use `BigDecimal.round()` to calculate the throughput, but It looks like we should use `BigDecimal.setScale()` for this case. And after this change, the throughput is shown as `1877.877`, which is more accurate.