### PR TITLE
Support Java 11 or later

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.google.inject', name: 'guice', version: '4.2.2'
+    implementation group: 'com.google.inject', name: 'guice', version: '5.1.0'
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation group: 'com.moandjiezana.toml', name: 'toml4j', version: '0.7.2'
     implementation group: 'info.picocli', name: 'picocli', version: '4.1.4'

--- a/src/main/java/com/scalar/kelpie/modules/ModuleLoader.java
+++ b/src/main/java/com/scalar/kelpie/modules/ModuleLoader.java
@@ -67,11 +67,9 @@ public class ModuleLoader {
 
   private Module loadModule(String className, String jarPath) throws ModuleLoadException {
     try {
-      URLClassLoader classLoader = (URLClassLoader) Thread.currentThread().getContextClassLoader();
       URL jarUrl = new File(jarPath).toURI().toURL();
-      Method method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
-      method.setAccessible(true);
-      method.invoke(classLoader, jarUrl);
+      URLClassLoader classLoader = new URLClassLoader(new URL[] { jarUrl }, Thread.currentThread().getContextClassLoader());
+      Thread.currentThread().setContextClassLoader(classLoader);
 
       @SuppressWarnings("unchecked")
       Class<Module> clazz = (Class<Module>) Class.forName(className, true, classLoader);


### PR DESCRIPTION
This PR fixes https://github.com/scalar-labs/kelpie/issues/29.

The current implementation tries to cast `jdk.internal.loader.ClassLoaders$AppClassLoader` to `java.net.URLClassLoader`. It works in Java 8, but doesn't work in Java 11 or later since `ClassLoaders$AppClassLoader` no longer inherit `java.net.URLClassLoader`.

The PR also upgrades the version of Guice since version 4 doesn't work with Java 17 or later.

I confirmed if this change works as follows:
- `./gradlew installDist` in the Kelpie project directory using Java 8
- Clone https://github.com/scalar-labs/scalardb-benchmarks, build a shadow Jar using Java, and execute the Kelpie Jar built above with 8, 11, 17 and 21
