### PR TITLE
Add integration test

### DIFF
--- a/.github/workflows/kelpie.yaml
+++ b/.github/workflows/kelpie.yaml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Build Kelpie-Test:print-modules
       working-directory: kelpie-test/print-modules
-      run: gradlew shadowJar
+      run: gradle shadowJar
 
     - name: Execute Kelpie-Test:print-modules
       working-directory: kelpie-test

--- a/.github/workflows/kelpie.yaml
+++ b/.github/workflows/kelpie.yaml
@@ -8,7 +8,8 @@ jobs:
     name: Build
     strategy:
       matrix:
-        java_version: [8, 11, 17, 21]
+          # java_version: [8, 11, 17, 21]
+        java_version: [8]
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/kelpie.yaml
+++ b/.github/workflows/kelpie.yaml
@@ -8,8 +8,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-          # java_version: [8, 11, 17, 21]
-        java_version: [8]
+        java_version: [8, 11, 17, 21]
     steps:
     - uses: actions/checkout@v4
 
@@ -44,7 +43,7 @@ jobs:
 
     - name: Build Kelpie-Test:print-modules
       working-directory: kelpie-test/print-modules
-      run: ${{ github.workspace }}/gradlew shadowJar
+      run: gradlew shadowJar
 
     - name: Execute Kelpie-Test:print-modules
       working-directory: kelpie-test

--- a/.github/workflows/kelpie.yaml
+++ b/.github/workflows/kelpie.yaml
@@ -20,7 +20,8 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        java-version: '8'
+        distribution: 'temurin'
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/kelpie.yaml
+++ b/.github/workflows/kelpie.yaml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Cache repository
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
@@ -40,7 +40,7 @@ jobs:
 
     - name: Build Kelpie-Test:print-modules
       working-directory: kelpie-test/print-modules
-      run: gradle shadowJar
+      run: ${{ github.workspace }}/gradlew shadowJar
 
     - name: Execute Kelpie-Test:print-modules
       working-directory: kelpie-test

--- a/.github/workflows/kelpie.yaml
+++ b/.github/workflows/kelpie.yaml
@@ -44,4 +44,4 @@ jobs:
 
     - name: Execute Kelpie-Test:print-modules
       working-directory: kelpie-test
-      run: ${{ github.workspace }}/build/libs/bin/kelpie --config print-modules/config.toml
+      run: ${{ github.workspace }}/build/install/kelpie/bin/kelpie --config print-modules/config.toml

--- a/.github/workflows/kelpie.yaml
+++ b/.github/workflows/kelpie.yaml
@@ -6,6 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build
+    matrix:
+      java_version: [8, 11, 17, 21]
     steps:
     - uses: actions/checkout@v4
 
@@ -20,7 +22,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v4
       with:
-        java-version: '8'
+        java-version: ${{ matrix.java_version }}
         distribution: 'temurin'
 
     - name: Setup Gradle

--- a/.github/workflows/kelpie.yaml
+++ b/.github/workflows/kelpie.yaml
@@ -1,13 +1,13 @@
 name: Kelpie
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     name: Build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Cache repository
       uses: actions/cache@v1
@@ -18,9 +18,29 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - name: Setup Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: 1.8
 
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
     - name: Build Kelpie
       run: ./gradlew build
+
+    - name: Install distribution of Kelpie
+      run: ./gradlew installDist
+
+    - name: Checkout Kelpie-Test
+      uses: actions/checkout@v4
+      with:
+        repository: scalar-labs/kelpie-test
+        path: kelpie-test
+
+    - name: Build Kelpie-Test:print-modules
+      working-directory: kelpie-test/print-modules
+      run: gradle shadowJar
+
+    - name: Execute Kelpie-Test:print-modules
+      working-directory: kelpie-test
+      run: ${{ github.workspace }}/build/libs/bin/kelpie --config print-modules/config.toml

--- a/.github/workflows/kelpie.yaml
+++ b/.github/workflows/kelpie.yaml
@@ -6,8 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build
-    matrix:
-      java_version: [8, 11, 17, 21]
+    strategy:
+      matrix:
+        java_version: [8, 11, 17, 21]
     steps:
     - uses: actions/checkout@v4
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,15 +23,11 @@ dependencies {
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.2.4'
 }
 
-task sourcesJar(type: Jar) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
-task javadocJar(type: Jar) {
-    classifier = 'javadoc'
-    from javadoc
-}
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
As per discussion with @yito88 https://github.com/scalar-labs/kelpie/pull/30#issuecomment-2553356282, we plan to add an integration test to see if Kelpie can work with Java 11 or later in addition to Java 8. This PR adds a simple integration test for that with minimum effort.

This PR includes:
- Add GitHub Actions steps to setup `kelpie-test:print-modules` and execute it with internally built Kelpie
- Upgrade the Gradle version to 8.11
- Update `build.gradle` to work with Gradle 8 since recent Javas require it.