### PR TITLE
Update Java version to 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,38 +3,49 @@ plugins {
     id 'application'
 }
 
-mainClassName = 'com.scalar.kelpie.Kelpie'
+group = "com.scalar-labs"
+base {
+    archivesName = "kelpie"
+}
 
 repositories {
     mavenCentral()
 }
 
-dependencies {
-    implementation group: 'com.google.inject', name: 'guice', version: '5.1.0'
-    implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    implementation group: 'com.moandjiezana.toml', name: 'toml4j', version: '0.7.2'
-    implementation group: 'info.picocli', name: 'picocli', version: '4.1.4'
-    implementation group: 'javax.json', name: 'javax.json-api', version: '1.1.4'
-    implementation group: 'org.glassfish', name: 'javax.json', version: '1.1.4'
-    implementation group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.30'
-    implementation group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.12'
-    testImplementation group: 'junit', name: 'junit', version: '4.13'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.14.0'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.2.4'
+application {
+    mainClass = 'com.scalar.kelpie.Kelpie'
 }
 
 java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
     withJavadocJar()
     withSourcesJar()
 }
 
+dependencies {
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+    // Core
+    implementation 'com.google.inject:guice:7.0.0'
+    implementation 'com.google.guava:guava:33.0.0-jre'
+    implementation 'com.moandjiezana.toml:toml4j:0.7.2'
+    implementation 'info.picocli:picocli:4.7.6'
 
-group = "com.scalar-labs"
-archivesBaseName = "kelpie"
-//version = "1.2.4"
+    // JSON (migrated to Jakarta)
+    implementation 'org.glassfish:javax.json:1.1.4'
 
-// for archiving and uploading to maven central
-//apply from: 'archive.gradle'
+    // Logging (safe replacement)
+    implementation 'ch.qos.logback:logback-classic:1.4.14'
+
+    implementation 'org.hdrhistogram:HdrHistogram:2.1.12'
+
+    // Testing - Modernized
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.mockito:mockito-core:5.10.0'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,6 @@ dependencies {
     implementation 'com.google.guava:guava:33.0.0-jre'
     implementation 'com.moandjiezana.toml:toml4j:0.7.2'
     implementation 'info.picocli:picocli:4.7.6'
-
-    // JSON (migrated to Jakarta)
     implementation 'org.glassfish:javax.json:1.1.4'
 
     // Logging (safe replacement)

--- a/src/main/java/com/scalar/kelpie/Kelpie.java
+++ b/src/main/java/com/scalar/kelpie/Kelpie.java
@@ -10,9 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
-/**
- * To execute kelpie jobs built with kelpie framework
- */
+/** To execute kelpie jobs built with kelpie framework */
 @CommandLine.Command(
     description = "Execute a job built with Kelpie framework.",
     name = "kelpie",
@@ -70,17 +68,14 @@ public class Kelpie implements Callable {
       description = "Execute the injectors")
   private boolean injected = false;
 
-  /**
-   * Creates a new instance of {@code Kelpie}.
-   */
-  public Kelpie() {
-  }
-
+  /** Creates a new instance of {@code Kelpie}. */
+  public Kelpie() {}
 
   /**
-   *  The entry point of the application.
-   * @param args command-line arguments passed to the application.
-   *  *             The array may be empty but is never {@code null}.
+   * The entry point of the application.
+   *
+   * @param args command-line arguments passed to the application. The array may be empty but is
+   *     never {@code null}.
    */
   public static void main(String[] args) {
     int exitCode = new CommandLine(new Kelpie()).execute(args);

--- a/src/main/java/com/scalar/kelpie/Kelpie.java
+++ b/src/main/java/com/scalar/kelpie/Kelpie.java
@@ -10,6 +10,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
+/**
+ * To execute kelpie jobs built with kelpie framework
+ */
 @CommandLine.Command(
     description = "Execute a job built with Kelpie framework.",
     name = "kelpie",
@@ -67,6 +70,18 @@ public class Kelpie implements Callable {
       description = "Execute the injectors")
   private boolean injected = false;
 
+  /**
+   * Creates a new instance of {@code Kelpie}.
+   */
+  public Kelpie() {
+  }
+
+
+  /**
+   *  The entry point of the application.
+   * @param args command-line arguments passed to the application.
+   *  *             The array may be empty but is never {@code null}.
+   */
   public static void main(String[] args) {
     int exitCode = new CommandLine(new Kelpie()).execute(args);
     System.exit(exitCode);

--- a/src/main/java/com/scalar/kelpie/KelpieModule.java
+++ b/src/main/java/com/scalar/kelpie/KelpieModule.java
@@ -11,10 +11,18 @@ import com.scalar.kelpie.modules.PreProcessor;
 import com.scalar.kelpie.modules.Processor;
 import java.util.List;
 
+/**
+ * Kelpie module to set up and load processors
+ */
 public class KelpieModule extends AbstractModule {
   private final Config config;
   private final ModuleLoader loader;
 
+  /**
+   * Creates a KelpieModule.
+   *
+   * @param config configuration object
+   */
   public KelpieModule(Config config) {
     this.config = config;
     this.loader = new ModuleLoader(config);

--- a/src/main/java/com/scalar/kelpie/exception/IllegalConfigException.java
+++ b/src/main/java/com/scalar/kelpie/exception/IllegalConfigException.java
@@ -18,7 +18,7 @@ public class IllegalConfigException extends RuntimeException {
    * Constructs a new {@code IllegalConfigException} with the specified detail message.
    *
    * @param message the detail message describing the cause of the exception
-   * @param  cause the underlying cause of the exception
+   * @param cause the underlying cause of the exception
    */
   public IllegalConfigException(String message, Throwable cause) {
     super(message, cause);

--- a/src/main/java/com/scalar/kelpie/exception/IllegalConfigException.java
+++ b/src/main/java/com/scalar/kelpie/exception/IllegalConfigException.java
@@ -1,11 +1,25 @@
 package com.scalar.kelpie.exception;
 
+/**
+ * Thrown to indicate that an error occurred while processing a config.
+ */
 public class IllegalConfigException extends RuntimeException {
 
+  /**
+   * Constructs a new {@code IllegalConfigException} with the specified detail message.
+   *
+   * @param message the detail message describing the cause of the exception
+   */
   public IllegalConfigException(String message) {
     super(message);
   }
 
+  /**
+   * Constructs a new {@code IllegalConfigException} with the specified detail message.
+   *
+   * @param message the detail message describing the cause of the exception
+   * @param  cause the underlying cause of the exception
+   */
   public IllegalConfigException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/src/main/java/com/scalar/kelpie/exception/InjectionException.java
+++ b/src/main/java/com/scalar/kelpie/exception/InjectionException.java
@@ -1,11 +1,25 @@
 package com.scalar.kelpie.exception;
 
+/**
+ * Thrown to indicate that an error occurred while injecting an injector
+ */
 public class InjectionException extends RuntimeException {
 
+  /**
+   * Constructs a new {@code InjectionException} with the specified detail message.
+   *
+   * @param message the detail message describing the cause of the exception
+   */
   public InjectionException(String message) {
     super(message);
   }
 
+  /**
+   * Constructs a new {@code InjectionException} with the specified detail message.
+   *
+   * @param message the detail message describing the cause of the exception
+   * @param  cause the underlying cause of the exception
+   */
   public InjectionException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/src/main/java/com/scalar/kelpie/exception/ModuleLoadException.java
+++ b/src/main/java/com/scalar/kelpie/exception/ModuleLoadException.java
@@ -1,11 +1,25 @@
 package com.scalar.kelpie.exception;
 
+/**
+ * Thrown to indicate that an error occurred while loading a module.
+ */
 public class ModuleLoadException extends RuntimeException {
 
+  /**
+   * Constructs a new {@code ModuleLoadException} with the specified detail message.
+   *
+   * @param message the detail message describing the cause of the exception
+   */
   public ModuleLoadException(String message) {
     super(message);
   }
 
+  /**
+   * Constructs a new {@code ModuleLoadException} with the specified detail message.
+   *
+   * @param message the detail message describing the cause of the exception
+   * @param  cause the underlying cause of the exception
+   */
   public ModuleLoadException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/src/main/java/com/scalar/kelpie/exception/PostProcessException.java
+++ b/src/main/java/com/scalar/kelpie/exception/PostProcessException.java
@@ -1,11 +1,25 @@
 package com.scalar.kelpie.exception;
 
+/**
+ * Thrown to indicate that an error occurred while executing PostProcessor
+ */
 public class PostProcessException extends RuntimeException {
 
+  /**
+   * Constructs a new {@code PostProcessException} with the specified detail message.
+   *
+   * @param message the detail message describing the cause of the exception
+   */
   public PostProcessException(String message) {
     super(message);
   }
 
+  /**
+   * Constructs a new {@code PostProcessException} with the specified detail message.
+   *
+   * @param message the detail message describing the cause of the exception
+   * @param  cause the underlying cause of the exception
+   */
   public PostProcessException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/src/main/java/com/scalar/kelpie/exception/PreProcessException.java
+++ b/src/main/java/com/scalar/kelpie/exception/PreProcessException.java
@@ -1,11 +1,25 @@
 package com.scalar.kelpie.exception;
 
+/**
+ * Thrown to indicate that an error occurred while executing PreProcessor
+ */
 public class PreProcessException extends RuntimeException {
 
+  /**
+   * Constructs a new {@code PreProcessException} with the specified detail message.
+   *
+   * @param message the detail message describing the cause of the exception
+   */
   public PreProcessException(String message) {
     super(message);
   }
 
+  /**
+   * Constructs a new {@code PreProcessException} with the specified detail message.
+   *
+   * @param message the detail message describing the cause of the exception
+   * @param  cause the underlying cause of the exception
+   */
   public PreProcessException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/src/main/java/com/scalar/kelpie/exception/ProcessException.java
+++ b/src/main/java/com/scalar/kelpie/exception/ProcessException.java
@@ -1,11 +1,25 @@
 package com.scalar.kelpie.exception;
 
+/**
+ * Thrown to indicate that an error occurred while executing Processor
+ */
 public class ProcessException extends RuntimeException {
 
+  /**
+   * Constructs a new {@code ProcessException} with the specified detail message.
+   *
+   * @param message the detail message describing the cause of the exception
+   */
   public ProcessException(String message) {
     super(message);
   }
 
+  /**
+   * Constructs a new {@code ProcessException} with the specified detail message.
+   *
+   * @param message the detail message describing the cause of the exception
+   * @param  cause the underlying cause of the exception
+   */
   public ProcessException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/src/main/java/com/scalar/kelpie/exception/ProcessFatalException.java
+++ b/src/main/java/com/scalar/kelpie/exception/ProcessFatalException.java
@@ -1,11 +1,25 @@
 package com.scalar.kelpie.exception;
 
+/**
+ * Thrown to indicate that an error occurred while executing process
+ */
 public class ProcessFatalException extends ProcessException {
 
+  /**
+   * Constructs a new {@code ProcessFatalException} with the specified detail message.
+   *
+   * @param message the detail message describing the cause of the exception
+   */
   public ProcessFatalException(String message) {
     super(message);
   }
 
+  /**
+   * Constructs a new {@code ProcessFatalException} with the specified detail message.
+   *
+   * @param message the detail message describing the cause of the exception
+   * @param  cause the underlying cause of the exception
+   */
   public ProcessFatalException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/src/main/java/com/scalar/kelpie/executor/InjectionExecutor.java
+++ b/src/main/java/com/scalar/kelpie/executor/InjectionExecutor.java
@@ -11,8 +11,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * InjectionExecutor}.
  */
 public abstract class InjectionExecutor {
+  /** list of injectors */
   protected List<Injector> injectors;
 
+  /**
+   * Creates a InjectionExecutor.
+   *
+   * @param injectors list of injectors
+   */
   public InjectionExecutor(List<Injector> injectors) {
     this.injectors = injectors;
   }

--- a/src/main/java/com/scalar/kelpie/executor/KelpieExecutor.java
+++ b/src/main/java/com/scalar/kelpie/executor/KelpieExecutor.java
@@ -34,7 +34,7 @@ public class KelpieExecutor {
    *
    * @param config configuration object
    * @param preProcessor preprocessor object
-   * @param  processor processor object
+   * @param processor processor object
    * @param postProcessor postprocessor object
    * @param injectors list of injectors
    */
@@ -55,9 +55,7 @@ public class KelpieExecutor {
     this.stats = new Stats(config);
   }
 
-  /**
-   * Executes the kelpie executor
-   */
+  /** Executes the kelpie executor */
   public void execute() {
     processor.setStats(stats);
     postProcessor.setStats(stats);
@@ -132,11 +130,9 @@ public class KelpieExecutor {
     String name = config.getInjectionExecutor().get();
     try {
       Class<? extends InjectionExecutor> clazz =
-              Class.forName(name).asSubclass(InjectionExecutor.class);
+          Class.forName(name).asSubclass(InjectionExecutor.class);
 
-      return clazz
-              .getConstructor(List.class)
-              .newInstance(injectors);
+      return clazz.getConstructor(List.class).newInstance(injectors);
     } catch (Exception e) {
       throw new InjectionException("Failed to load InjectionExecutor " + name, e);
     }

--- a/src/main/java/com/scalar/kelpie/executor/KelpieExecutor.java
+++ b/src/main/java/com/scalar/kelpie/executor/KelpieExecutor.java
@@ -29,6 +29,15 @@ public class KelpieExecutor {
   private final AtomicBoolean isDone;
   private final Stats stats;
 
+  /**
+   * Creates a KelpieExecutor.
+   *
+   * @param config configuration object
+   * @param preProcessor preprocessor object
+   * @param  processor processor object
+   * @param postProcessor postprocessor object
+   * @param injectors list of injectors
+   */
   @Inject
   public KelpieExecutor(
       Config config,
@@ -46,6 +55,9 @@ public class KelpieExecutor {
     this.stats = new Stats(config);
   }
 
+  /**
+   * Executes the kelpie executor
+   */
   public void execute() {
     processor.setStats(stats);
     postProcessor.setStats(stats);
@@ -119,11 +131,12 @@ public class KelpieExecutor {
   private InjectionExecutor loadInjectionExecutor() {
     String name = config.getInjectionExecutor().get();
     try {
-      Class clazz = Class.forName(name);
-      Class[] types = {List.class};
-      Object[] args = {injectors};
+      Class<? extends InjectionExecutor> clazz =
+              Class.forName(name).asSubclass(InjectionExecutor.class);
 
-      return (InjectionExecutor) clazz.getConstructor(types).newInstance(args);
+      return clazz
+              .getConstructor(List.class)
+              .newInstance(injectors);
     } catch (Exception e) {
       throw new InjectionException("Failed to load InjectionExecutor " + name, e);
     }

--- a/src/main/java/com/scalar/kelpie/executor/OnetimeInjectionExecutor.java
+++ b/src/main/java/com/scalar/kelpie/executor/OnetimeInjectionExecutor.java
@@ -11,6 +11,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /** OnetimeInjectionExecutor executes all {@link Injector}s once. */
 public class OnetimeInjectionExecutor extends InjectionExecutor {
 
+  /**
+   * Creates a OnetimeInjectionExecutor.
+   *
+   * @param injectors list of injectors
+   */
   public OnetimeInjectionExecutor(List<Injector> injectors) {
     super(injectors);
   }

--- a/src/main/java/com/scalar/kelpie/executor/RandomInjectionExecutor.java
+++ b/src/main/java/com/scalar/kelpie/executor/RandomInjectionExecutor.java
@@ -9,6 +9,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class RandomInjectionExecutor extends InjectionExecutor {
   private final Random random;
 
+  /**
+   * Creates a RandomInjectionExecutor.
+   *
+   * @param injectors list of injectors
+   */
   public RandomInjectionExecutor(List<Injector> injectors) {
     super(injectors);
     this.random = new Random(System.currentTimeMillis());

--- a/src/main/java/com/scalar/kelpie/executor/SequentialInjectionExecutor.java
+++ b/src/main/java/com/scalar/kelpie/executor/SequentialInjectionExecutor.java
@@ -7,6 +7,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /** SequentialInjectionExecutor executes each {@link Injector} one by one. */
 public class SequentialInjectionExecutor extends InjectionExecutor {
 
+  /**
+   * Creates a SequentialInjectionExecutor.
+   *
+   * @param injectors list of injectors
+   */
   public SequentialInjectionExecutor(List<Injector> injectors) {
     super(injectors);
   }

--- a/src/main/java/com/scalar/kelpie/modules/FrequencyBasedProcessor.java
+++ b/src/main/java/com/scalar/kelpie/modules/FrequencyBasedProcessor.java
@@ -9,10 +9,10 @@ import java.util.stream.LongStream;
 /** FrequencyBasedProcessor executes operations by the configured count. */
 public abstract class FrequencyBasedProcessor extends Processor {
   /**
-    * Creates a FrequencyBasedProcessor.
-    *
-    * @param config configuration object
-  */
+   * Creates a FrequencyBasedProcessor.
+   *
+   * @param config configuration object
+   */
   public FrequencyBasedProcessor(Config config) {
     super(config);
   }

--- a/src/main/java/com/scalar/kelpie/modules/FrequencyBasedProcessor.java
+++ b/src/main/java/com/scalar/kelpie/modules/FrequencyBasedProcessor.java
@@ -8,6 +8,11 @@ import java.util.stream.LongStream;
 
 /** FrequencyBasedProcessor executes operations by the configured count. */
 public abstract class FrequencyBasedProcessor extends Processor {
+  /**
+    * Creates a FrequencyBasedProcessor.
+    *
+    * @param config configuration object
+  */
   public FrequencyBasedProcessor(Config config) {
     super(config);
   }

--- a/src/main/java/com/scalar/kelpie/modules/Module.java
+++ b/src/main/java/com/scalar/kelpie/modules/Module.java
@@ -7,9 +7,19 @@ import org.slf4j.LoggerFactory;
 
 /** A Module abstraction to execute tasks. */
 public abstract class Module implements AutoCloseable {
+
+  /**
+   * The default state represented as an empty {@link JsonObject}.
+   *
+   * <p>This constant is used as the initial or fallback state when
+   * no explicit state is provided.</p>
+   */
   protected static final JsonObject DEFAULT_STATE = JsonObject.EMPTY_JSON_OBJECT;
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
+  /**
+   * configuration object
+   */
   protected Config config;
   private JsonObject state;
   private JsonObject previousState;

--- a/src/main/java/com/scalar/kelpie/modules/ModuleLoader.java
+++ b/src/main/java/com/scalar/kelpie/modules/ModuleLoader.java
@@ -29,9 +29,9 @@ public class ModuleLoader {
   }
 
   /**
-   * Loads a PreProcessor object
-   * @return PreProcessor object
-   * @throws ModuleLoadException object
+   * Loads the pre-processor module specified in the configuration.
+   * @return the loaded {@link PreProcessor}
+   * @throws ModuleLoadException if the module fails to load
    */
   public PreProcessor loadPreProcessor() throws ModuleLoadException {
     if (config.isPreProcessorEnabled()) {

--- a/src/main/java/com/scalar/kelpie/modules/ModuleLoader.java
+++ b/src/main/java/com/scalar/kelpie/modules/ModuleLoader.java
@@ -19,10 +19,20 @@ import java.util.List;
 public class ModuleLoader {
   private Config config;
 
+  /**
+   * Creates a ModuleLoader.
+   *
+   * @param config configuration object
+   */
   public ModuleLoader(Config config) {
     this.config = config;
   }
 
+  /**
+   * Loads a PreProcessor object
+   * @return PreProcessor object
+   * @throws ModuleLoadException object
+   */
   public PreProcessor loadPreProcessor() throws ModuleLoadException {
     if (config.isPreProcessorEnabled()) {
       return (PreProcessor)
@@ -32,6 +42,11 @@ public class ModuleLoader {
     }
   }
 
+  /**
+   * Loads a Processor object
+   * @return Processor object
+   * @throws ModuleLoadException object
+   */
   public Processor loadProcessor() throws ModuleLoadException {
     if (config.isProcessorEnabled()) {
       return (Processor)
@@ -41,6 +56,11 @@ public class ModuleLoader {
     }
   }
 
+  /**
+   * Loads a PostProcessor object
+   * @return PostProcessor object
+   * @throws ModuleLoadException object
+   */
   public PostProcessor loadPostProcessor() throws ModuleLoadException {
     if (config.isPostProcessorEnabled()) {
       return (PostProcessor)
@@ -50,7 +70,20 @@ public class ModuleLoader {
     }
   }
 
-  public List<Injector> loadInjectors() throws ModuleLoadException {
+/**
+ * Loads and initializes all configured {@link Injector} modules.
+ *
+ * <p>If injector support is enabled in the configuration, this method
+ * iterates through the configured injector definitions, dynamically
+ * loads each module, and returns them as a list.</p>
+ *
+ * <p>If injectors are disabled, an empty list is returned.</p>
+ *
+ * @return a list of successfully loaded {@link Injector} instances;
+ *         never {@code null}
+ * @throws ModuleLoadException if any configured injector module
+ */
+public List<Injector> loadInjectors() throws ModuleLoadException {
     List<Injector> injectors = new ArrayList<>();
 
     if (config.isInjectorEnabled()) {

--- a/src/main/java/com/scalar/kelpie/modules/PostProcessor.java
+++ b/src/main/java/com/scalar/kelpie/modules/PostProcessor.java
@@ -7,10 +7,18 @@ import com.scalar.kelpie.stats.Stats;
 public abstract class PostProcessor extends Module {
   private Stats stats;
 
+  /**
+   * Creates a PostProcessor.
+   *
+   * @param config configuration object
+   */
   public PostProcessor(Config config) {
     super(config);
   }
 
+  /**
+   * Executes PostProcessor
+   */
   public abstract void execute();
 
   /**

--- a/src/main/java/com/scalar/kelpie/modules/PreProcessor.java
+++ b/src/main/java/com/scalar/kelpie/modules/PreProcessor.java
@@ -5,9 +5,17 @@ import com.scalar.kelpie.config.Config;
 /** PreProcessor executes a process before {@link Processor#execute()}. */
 public abstract class PreProcessor extends Module {
 
+  /**
+   * Creates a PreProcessor.
+   *
+   * @param config configuration object
+   */
   public PreProcessor(Config config) {
     super(config);
   }
 
+  /**
+   * Executes PreProcessor
+   */
   public abstract void execute();
 }

--- a/src/main/java/com/scalar/kelpie/modules/Processor.java
+++ b/src/main/java/com/scalar/kelpie/modules/Processor.java
@@ -6,11 +6,19 @@ import com.scalar.kelpie.stats.Stats;
 /** Processor executes operations. */
 public abstract class Processor extends Module {
   private Stats stats;
+  /**
+   * Creates a Processor.
+   *
+   * @param config configuration object
+   */
 
   public Processor(Config config) {
     super(config);
   }
 
+  /**
+   * Executes Processor
+   */
   public abstract void execute();
 
   /**
@@ -82,6 +90,6 @@ public abstract class Processor extends Module {
   }
 
   private String prependThreadId(String message) {
-    return "[Thread " + Thread.currentThread().getId() + "] " + message;
+    return "[Thread " + Thread.currentThread().threadId() + "] " + message;
   }
 }

--- a/src/main/java/com/scalar/kelpie/modules/TimeBasedProcessor.java
+++ b/src/main/java/com/scalar/kelpie/modules/TimeBasedProcessor.java
@@ -7,6 +7,12 @@ import java.util.function.Supplier;
 
 /** TimeBasedProcessor executes operations for the configured time. */
 public abstract class TimeBasedProcessor extends Processor {
+
+  /**
+   * Creates a TimeBasedProcessor.
+   *
+   * @param config configuration object
+   */
   public TimeBasedProcessor(Config config) {
     super(config);
   }

--- a/src/main/java/com/scalar/kelpie/modules/dummy/DummyPostProcessor.java
+++ b/src/main/java/com/scalar/kelpie/modules/dummy/DummyPostProcessor.java
@@ -6,6 +6,11 @@ import com.scalar.kelpie.modules.PostProcessor;
 /** DummyPostProcessor is a dummy module of {@link PostProcessor} and executes nothing. */
 public class DummyPostProcessor extends PostProcessor {
 
+  /**
+   * Creates a DummyPostProcessor.
+   *
+   * @param config configuration object
+   */
   public DummyPostProcessor(Config config) {
     super(config);
   }

--- a/src/main/java/com/scalar/kelpie/modules/dummy/DummyPreProcessor.java
+++ b/src/main/java/com/scalar/kelpie/modules/dummy/DummyPreProcessor.java
@@ -6,6 +6,11 @@ import com.scalar.kelpie.modules.PreProcessor;
 /** DummyPreProcessor is a dummy module of {@link PreProcessor} and executes nothing. */
 public class DummyPreProcessor extends PreProcessor {
 
+  /**
+   * Creates a DummyPreProcessor.
+   *
+   * @param config configuration object
+   */
   public DummyPreProcessor(Config config) {
     super(config);
   }

--- a/src/main/java/com/scalar/kelpie/modules/dummy/DummyProcessor.java
+++ b/src/main/java/com/scalar/kelpie/modules/dummy/DummyProcessor.java
@@ -6,6 +6,11 @@ import com.scalar.kelpie.modules.Processor;
 /** DummyProcessor is a dummy module of {@link Processor} and executes nothing. */
 public class DummyProcessor extends Processor {
 
+  /**
+   * Creates a DummyProcessor.
+   *
+   * @param config configuration object
+  */
   public DummyProcessor(Config config) {
     super(config);
   }

--- a/src/main/java/com/scalar/kelpie/modules/dummy/DummyProcessor.java
+++ b/src/main/java/com/scalar/kelpie/modules/dummy/DummyProcessor.java
@@ -10,7 +10,7 @@ public class DummyProcessor extends Processor {
    * Creates a DummyProcessor.
    *
    * @param config configuration object
-  */
+   */
   public DummyProcessor(Config config) {
     super(config);
   }

--- a/src/main/java/com/scalar/kelpie/stats/Stats.java
+++ b/src/main/java/com/scalar/kelpie/stats/Stats.java
@@ -164,9 +164,25 @@ public class Stats {
         .doubleValue();
   }
 
+  /**
+   * A {@link Runnable} implementation that periodically reports
+   * real-time throughput and execution statistics.
+   *
+   * <p>This reporter runs in a background thread and logs the
+   * current throughput (operations per second), along with total
+   * success and failure counts, at fixed time intervals.</p>
+   *
+   * <p>The reporting loop continues until the provided
+   * {@link AtomicBoolean} flag is set to {@code true}.</p>
+   */
   public class RealtimeReport implements Runnable {
     private AtomicBoolean isDone;
 
+    /**
+     * Creates a RealtimeReport
+     *
+     * @param isDone boolean flag to indicate process is done
+     */
     public RealtimeReport(AtomicBoolean isDone) {
       this.isDone = isDone;
     }

--- a/src/test/java/com/scalar/kelpie/config/ConfigTest.java
+++ b/src/test/java/com/scalar/kelpie/config/ConfigTest.java
@@ -7,7 +7,7 @@ import com.scalar.kelpie.exception.IllegalConfigException;
 import java.io.File;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConfigTest {
   static final String ANY_PRE_NAME = "my.PreProcessor";


### PR DESCRIPTION
## Description

Recently scalardl java version was updated to Java 21. In order to support it and avoid issues, in this PR I have updated the Java version for kelpie which is used in daily verification and benchmark tests.
The Jira ticket for this change : https://scalar-labs.atlassian.net/browse/DLT-18283
I have tested and confirmed the changes in my local environment (with scalardb and scalardl kelpie tests, also updated to support Java 21)

## Related issues and/or PRs

NA

## Changes made

* I have updated the gradle version 8 to support Java 21
* I have updated the dependencies in the gradle file in order to support the Java version change
* I have added javadoc comments to remove warnings

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)
I have not update the CI workflow in the project.
