### PR TITLE
Remove v  in tag from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   release:


### PR DESCRIPTION
In this PR, I have removed `v` in tag from release workflow.
This was done as per the comment https://scalar-labs.slack.com/archives/CDSFWGSTZ/p1778566041272689?thread_ts=1776154295.361149&cid=CDSFWGSTZ from @jnmt san.
The same pattern is also used in scalardb analytics repo: https://github.com/scalar-labs/scalardb-analytics/blob/main/.github/workflows/release.yaml#L6